### PR TITLE
Set DemoNamespaceId and DemoGroupId value to zero if not set.

### DIFF
--- a/src/backend/models/user.go
+++ b/src/backend/models/user.go
@@ -1,7 +1,6 @@
 package models
 
 import (
-	"strconv"
 	"time"
 
 	"github.com/Qihoo360/wayne/src/backend/util/encode"
@@ -94,11 +93,8 @@ func (*userModel) AddUser(m *User) (id int64, err error) {
 
 func addDefaultNamespace(user *User) (err error) {
 	// 添加默认命名空间开发者权限
-	demoNSId, err := strconv.ParseInt(beego.AppConfig.DefaultString("DemoNamespaceId", "0"), 10, 64)
-	if err != nil {
-		return
-	}
-	demoGroupId, err := strconv.ParseInt(beego.AppConfig.DefaultString("DemoGroupId", "0"), 10, 64)
+	demoNSId := beego.AppConfig.DefaultInt64("DemoNamespaceId", 1)
+	demoGroupId := beego.AppConfig.DefaultInt64("DemoGroupId", 1)
 	if err != nil {
 		return
 	}

--- a/src/backend/models/user.go
+++ b/src/backend/models/user.go
@@ -94,11 +94,11 @@ func (*userModel) AddUser(m *User) (id int64, err error) {
 
 func addDefaultNamespace(user *User) (err error) {
 	// 添加默认命名空间开发者权限
-	demoNSId, err := strconv.ParseInt(beego.AppConfig.String("DemoNamespaceId"), 10, 64)
+	demoNSId, err := strconv.ParseInt(beego.AppConfig.DefaultString("DemoNamespaceId", "0"), 10, 64)
 	if err != nil {
 		return
 	}
-	demoGroupId, err := strconv.ParseInt(beego.AppConfig.String("DemoGroupId"), 10, 64)
+	demoGroupId, err := strconv.ParseInt(beego.AppConfig.DefaultString("DemoGroupId", "0"), 10, 64)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
Signed-off-by: Frank Kung <kfanjian@gmail.com>

<!--  Thanks for sending a pull request! 
-->

**What type of PR is this?**
> Uncomment only one, leave it on its own line:
>
> /kind bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
if Not Set value of DemoNamespaceId/DemoGroupId fields in app.conf, when user login auth type is db, we will get error: **strconv.ParseInt: parsing "": invalid syntax**

**Special notes for your reviewer**:
Just need set default value of DemoNamespaceId/DemoGroupId to fix it.

```release-note

```
