### PR TITLE
Add ComponentLabelKey to controllers

### DIFF
--- a/hack/kubernetes/wayne/configmap.yaml
+++ b/hack/kubernetes/wayne/configmap.yaml
@@ -27,6 +27,7 @@ data:
 
     # kubernetes labels config
     AppLabelKey= wayne-app
+    ComponentLabelKey = wayne-component
     NamespaceLabelKey = wayne-ns
     PodAnnotationControllerKindLabelKey = wayne.cloud/controller-kind
 

--- a/src/backend/controllers/config/baseconfig.go
+++ b/src/backend/controllers/config/baseconfig.go
@@ -30,6 +30,7 @@ func (c *BaseConfigController) ListBase() {
 	configMap["betaUrl"] = beego.AppConfig.String("BetaUrl")
 	configMap["enableDBLogin"] = beego.AppConfig.DefaultBool("EnableDBLogin", false)
 	configMap["appLabelKey"] = util.AppLabelKey
+	configMap["componentLabelKey"] = util.ComponentLabelKey
 	configMap["namespaceLabelKey"] = util.NamespaceLabelKey
 	configMap["enableRobin"] = beego.AppConfig.DefaultBool("EnableRobin", false)
 	configMap["ldapLogin"] = parseAuthEnabled("auth.ldap")

--- a/src/backend/initial/kube_label.go
+++ b/src/backend/initial/kube_label.go
@@ -7,6 +7,7 @@ import (
 
 func InitKubeLabel() {
 	util.AppLabelKey = beego.AppConfig.DefaultString("AppLabelKey", "wayne-app")
+	util.ComponentLabelKey = beego.AppConfig.DefaultString("ComponentLabelKey", "wayne-component")
 	util.NamespaceLabelKey = beego.AppConfig.DefaultString("NamespaceLabelKey", "wayne-ns")
 	util.PodAnnotationControllerKindLabelKey = beego.AppConfig.DefaultString("PodAnnotationControllerKindLabelKey", "wayne.cloud/controller-kind")
 }

--- a/src/backend/util/const.go
+++ b/src/backend/util/const.go
@@ -2,6 +2,7 @@ package util
 
 var (
 	AppLabelKey                         = ""
+	ComponentLabelKey                   = ""
 	NamespaceLabelKey                   = ""
 	PodAnnotationControllerKindLabelKey = ""
 )

--- a/src/frontend/src/app/portal/cronjob/create-edit-cronjobtpl/create-edit-cronjobtpl.component.ts
+++ b/src/frontend/src/app/portal/cronjob/create-edit-cronjobtpl/create-edit-cronjobtpl.component.ts
@@ -25,8 +25,8 @@ import {Cronjob} from '../../../shared/model/v1/cronjob';
 import {CronjobTplService} from '../../../shared/client/v1/cronjobtpl.service';
 import {CronjobService} from '../../../shared/client/v1/cronjob.service';
 import {AppService} from '../../../shared/client/v1/app.service';
-import {ActionType, appLabelKey, defaultResources, namespaceLabelKey} from '../../../shared/shared.const';
-import {mergeDeep, ResourceUnitConvertor} from '../../../shared/utils';
+import {ActionType, defaultResources, appLabelKey, componentLabelKey, namespaceLabelKey} from '../../../shared/shared.const';
+import {mergeDeep, ResourceUnitConvertor, ApiNameGenerateRule} from '../../../shared/utils';
 import {CacheService} from '../../../shared/auth/cache.service';
 import {AuthService} from '../../../shared/auth/auth.service';
 import {AceEditorService} from '../../../shared/ace-editor/ace-editor.service';
@@ -265,6 +265,7 @@ export class CreateEditCronjobTplComponent implements OnInit, AfterViewInit, OnD
       labels = {};
     }
     labels[this.authService.config[appLabelKey]] = this.app.name;
+    labels[this.authService.config[componentLabelKey]] = ApiNameGenerateRule.extractName(this.cronjob.name, this.app.name);
     labels[this.authService.config[namespaceLabelKey]] = this.cacheService.currentNamespace.name;
     labels['app'] = this.cronjob.name;
     return labels;

--- a/src/frontend/src/app/portal/daemonset/create-edit-daemonsettpl/create-edit-daemonsettpl.component.ts
+++ b/src/frontend/src/app/portal/daemonset/create-edit-daemonsettpl/create-edit-daemonsettpl.component.ts
@@ -22,7 +22,7 @@ import 'rxjs/add/observable/combineLatest';
 import {ActivatedRoute, Router} from '@angular/router';
 import {App} from '../../../shared/model/v1/app';
 import {AppService} from '../../../shared/client/v1/app.service';
-import {ActionType, appLabelKey, defaultResources, namespaceLabelKey} from '../../../shared/shared.const';
+import {ActionType, defaultResources, appLabelKey, componentLabelKey, namespaceLabelKey} from '../../../shared/shared.const';
 import {CacheService} from '../../../shared/auth/cache.service';
 import {Observable} from 'rxjs/Observable';
 import {AuthService} from '../../../shared/auth/auth.service';
@@ -33,7 +33,7 @@ import {DaemonSet} from '../../../shared/model/v1/daemonset';
 import {DaemonSetService} from '../../../shared/client/v1/daemonset.service';
 import {DaemonSetTplService} from '../../../shared/client/v1/daemonsettpl.service';
 import {defaultDaemonSet} from '../../../shared/default-models/daemonset.const';
-import {ResourceUnitConvertor} from '../../../shared/utils';
+import {ResourceUnitConvertor, ApiNameGenerateRule} from '../../../shared/utils';
 import {ConfigMapEnvSource, EnvFromSource, SecretEnvSource} from '../../../shared/model/v1/kubernetes/deployment';
 
 const templateDom = [
@@ -245,6 +245,7 @@ export class CreateEditDaemonSetTplComponent implements OnInit, AfterViewInit, O
       labels = {};
     }
     labels[this.authService.config[appLabelKey]] = this.app.name;
+    labels[this.authService.config[componentLabelKey]] = ApiNameGenerateRule.extractName(this.daemonSet.name, this.app.name);
     labels[this.authService.config[namespaceLabelKey]] = this.cacheService.currentNamespace.name;
     labels['app'] = this.daemonSet.name;
     return labels;

--- a/src/frontend/src/app/portal/deployment/create-edit-deployment/create-edit-deployment.component.ts
+++ b/src/frontend/src/app/portal/deployment/create-edit-deployment/create-edit-deployment.component.ts
@@ -173,8 +173,8 @@ export class CreateEditDeploymentComponent implements OnInit {
     this.deployment.metaData = this.formatMetaData();
     switch (this.actionType) {
       case ActionType.ADD_NEW:
-        this.deployment.name = ApiNameGenerateRule.generateName(ApiNameGenerateRule.config(
-          this.authService.config[configKeyApiNameGenerateRule], this.app.metaData),
+        this.deployment.name = ApiNameGenerateRule.generateName(
+          ApiNameGenerateRule.config(this.authService.config[configKeyApiNameGenerateRule], this.app.metaData),
           this.deployment.name, this.app.name);
         this.deploymentService.create(this.deployment).subscribe(
           response => {

--- a/src/frontend/src/app/portal/deployment/create-edit-deploymenttpl/create-edit-deploymenttpl.component.ts
+++ b/src/frontend/src/app/portal/deployment/create-edit-deploymenttpl/create-edit-deploymenttpl.component.ts
@@ -34,8 +34,8 @@ import {Deployment} from '../../../shared/model/v1/deployment';
 import {DeploymentTplService} from '../../../shared/client/v1/deploymenttpl.service';
 import {DeploymentService} from '../../../shared/client/v1/deployment.service';
 import {AppService} from '../../../shared/client/v1/app.service';
-import {ActionType, appLabelKey, defaultResources, namespaceLabelKey} from '../../../shared/shared.const';
-import {ResourceUnitConvertor} from '../../../shared/utils';
+import {ActionType, defaultResources, appLabelKey, componentLabelKey, namespaceLabelKey} from '../../../shared/shared.const';
+import {ResourceUnitConvertor, ApiNameGenerateRule} from '../../../shared/utils';
 import {CacheService} from '../../../shared/auth/cache.service';
 import {AuthService} from '../../../shared/auth/auth.service';
 import {AceEditorService} from '../../../shared/ace-editor/ace-editor.service';
@@ -279,6 +279,7 @@ export class CreateEditDeploymentTplComponent implements OnInit, AfterViewInit, 
       labels = {};
     }
     labels[this.authService.config[appLabelKey]] = this.app.name;
+    labels[this.authService.config[componentLabelKey]] = ApiNameGenerateRule.extractName(this.deployment.name, this.app.name);
     labels[this.authService.config[namespaceLabelKey]] = this.cacheService.currentNamespace.name;
     labels['app'] = this.deployment.name;
     return labels;

--- a/src/frontend/src/app/portal/statefulset/create-edit-statefulsettpl/create-edit-statefulsettpl.component.ts
+++ b/src/frontend/src/app/portal/statefulset/create-edit-statefulsettpl/create-edit-statefulsettpl.component.ts
@@ -24,7 +24,7 @@ import {ActivatedRoute, Router} from '@angular/router';
 import {App} from '../../../shared/model/v1/app';
 import {StatefulsetService} from '../../../shared/client/v1/statefulset.service';
 import {AppService} from '../../../shared/client/v1/app.service';
-import {ActionType, appLabelKey, defaultResources, namespaceLabelKey} from '../../../shared/shared.const';
+import {ActionType, defaultResources, appLabelKey, componentLabelKey, namespaceLabelKey} from '../../../shared/shared.const';
 import {CacheService} from '../../../shared/auth/cache.service';
 import {Statefulset} from '../../../shared/model/v1/statefulset';
 import {StatefulsetTplService} from '../../../shared/client/v1/statefulsettpl.service';
@@ -34,7 +34,7 @@ import {Observable} from 'rxjs/Observable';
 import {AuthService} from '../../../shared/auth/auth.service';
 import {AceEditorService} from '../../../shared/ace-editor/ace-editor.service';
 import {AceEditorMsg} from '../../../shared/ace-editor/ace-editor';
-import {ResourceUnitConvertor} from '../../../shared/utils';
+import {ResourceUnitConvertor, ApiNameGenerateRule} from '../../../shared/utils';
 import {ConfigMapEnvSource, EnvFromSource, SecretEnvSource} from '../../../shared/model/v1/kubernetes/deployment';
 
 const templateDom = [
@@ -246,6 +246,7 @@ export class CreateEditStatefulsettplComponent implements OnInit, AfterViewInit,
       labels = {};
     }
     labels[this.authService.config[appLabelKey]] = this.app.name;
+    labels[this.authService.config[componentLabelKey]] = ApiNameGenerateRule.extractName(this.statefulset.name, this.app.name);
     labels[this.authService.config[namespaceLabelKey]] = this.cacheService.currentNamespace.name;
     labels['app'] = this.statefulset.name;
     return labels;

--- a/src/frontend/src/app/shared/shared.const.ts
+++ b/src/frontend/src/app/shared/shared.const.ts
@@ -30,6 +30,7 @@ export const defaultResources = {
 };
 
 export const appLabelKey = 'appLabelKey';
+export const componentLabelKey = 'componentLabelKey';
 export const namespaceLabelKey = 'namespaceLabelKey';
 
 export const defaultRoutingUrl = 'portal/namespace/0/app';

--- a/src/frontend/src/app/shared/utils.ts
+++ b/src/frontend/src/app/shared/utils.ts
@@ -78,6 +78,13 @@ export class ApiNameGenerateRule {
     }
     return apiName;
   }
+
+  static extractName(apiName: string, appName: string): string {
+    if (apiName.length <= appName.length) {
+      return apiName;
+    }
+    return apiName.startsWith(appName) ? apiName.slice(appName.length + 1) : apiName;
+  }
 }
 
 export class ResourceUnitConvertor {


### PR DESCRIPTION
Add ComponentLabelKey(wayne-component) to controllers(Deployment, Daemonset, etc)
to store the origin name(without App name prefix). It's somekind of
recommendation in Kubernetes document:
https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/

<!--  Thanks for sending a pull request! 
-->

**What type of PR is this?**
> /kind enhancement


**What this PR does / why we need it**:
Store the origin(raw) name of controllers and we can make use of it in other system like Prometheus and filebeat.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Other labels like `app.kubernetes.io/instance` are not implemented. But it's worth to consider adding a `app.kubernetes.io/managed-by=wayne` label. It's the recommend way to label "The tool being used to manage the operation of an application".
