### PR TITLE
fix translate DEPLOYMENT_TMP_LIST

### DIFF
--- a/src/frontend/src/app/admin/deploymenttpl/deploymenttpl.component.html
+++ b/src/frontend/src/app/admin/deploymenttpl/deploymenttpl.component.html
@@ -1,7 +1,7 @@
 <div class="row">
   <div class="col-lg-12 col-md-12 col-sm-12 col-xs-12">
     <div class="row flex-items-xs-between flex-items-xs-top" style="padding-left: 15px; padding-right: 15px;">
-      <h2 class="header-title">{{'DEPLOYMENT_ADMIN.TMP.DEPLOYMENT_TMP_LIST'}}</h2>
+      <h2 class="header-title">{{'DEPLOYMENT_ADMIN.TMP.DEPLOYMENT_TMP_LIST' | translate}}</h2>
     </div>
     <div class="row flex-items-xs-between" style="height:32px;">
       <div class="option-left">


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Your PR title will add to changelog. Summarize the problem of the current submission in one sentence, beginning with English capitalization
-->

Should translate DEPLOYMENT_ADMIN.TMP.DEPLOYMENT_TMP_LIST, or we will get "DEPLOYMENT_ADMIN.TMP.DEPLOYMENT_TMP_LIST" on the web site.

**What type of PR is this?**

 /kind bug

**What this PR does / why we need it**:

Should translate DEPLOYMENT_ADMIN.TMP.DEPLOYMENT_TMP_LIST, or we will get "DEPLOYMENT_ADMIN.TMP.DEPLOYMENT_TMP_LIST" on the web site.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

