### PR TITLE
在POD页面增加ELK链接功能

### DIFF
--- a/src/frontend/src/app/shared/list-pod/list-pod.component.html
+++ b/src/frontend/src/app/shared/list-pod/list-pod.component.html
@@ -68,6 +68,7 @@
         <clr-dg-cell>
           <button class="wayne-button text" (click)="enterContainer(pod)"> {{'POD.ENTER_CONTAINER' | translate}}</button>
           <button *ngIf="logSource" class="wayne-button text" (click)="copyLogCommand(pod)">{{'POD.LOG_COMMAND' | translate}}</button>
+          <button *ngIf="logELK" class="wayne-button text" (click)="openlogELK(pod)">ELK {{'POD.LOG' | translate}}</button>
           <button class="wayne-button text" (click)="podLog(pod)"> {{'POD.LOG' | translate}}</button>
           <button class="wayne-button text" (click)="deletePod(pod)">{{'BUTTON.DELETE' | translate}}</button>
         </clr-dg-cell>


### PR DESCRIPTION


**What type of PR is this?**
 /kind feature


**What this PR does / why we need it**:
背景：
在使用wayne k8s同时我们也使用elk作为日志收集，但在kibana上找到对应的deployment pod日志实在太痛苦了，如果在pod页面上创建一个超链接，期待直接跳转到ELK日志平台是

实现：
参照了 logSource 实现方式：
1）集群MetaData变量中支持配置logELK变量，同时支持变量注入：
 logELK: http://192.168.3.18:5601/app/kibana?deployment=${k8s_deployment})&pod=${k8s_pod})

2）如果logELK变量设置了，pod页面出现ELK日志链接，点击可以访问