### PR TITLE
[issue 572]: fix log format

### DIFF
--- a/src/backend/controllers/apikey/apikey.go
+++ b/src/backend/controllers/apikey/apikey.go
@@ -80,14 +80,14 @@ func (c *ApiKeyController) List() {
 	param.Relate = "Group"
 	total, err := models.GetTotal(new(models.APIKey), param)
 	if err != nil {
-		logs.Error("get total count by param (%s) error. %v", param, err)
+		logs.Error("get total count by param (%v) error. %v", param, err)
 		c.HandleError(err)
 		return
 	}
 
 	err = models.GetAll(new(models.APIKey), &apiKeys, param)
 	if err != nil {
-		logs.Error("list by param (%s) error. %v", param, err)
+		logs.Error("list by param (%v) error. %v", param, err)
 		c.HandleError(err)
 		return
 	}

--- a/src/backend/controllers/auditlog/auditlog.go
+++ b/src/backend/controllers/auditlog/auditlog.go
@@ -56,14 +56,14 @@ func (c *AuditLogController) List() {
 
 	total, err := models.GetTotal(new(models.AuditLog), param)
 	if err != nil {
-		logs.Error("get total count by param (%s) error. %v", param, err)
+		logs.Error("get total count by param (%v) error. %v", param, err)
 		c.HandleError(err)
 		return
 	}
 
 	err = models.GetAll(new(models.AuditLog), &auditLogs, param)
 	if err != nil {
-		logs.Error("list by param (%s) error. %v", param, err)
+		logs.Error("list by param (%v) error. %v", param, err)
 		c.HandleError(err)
 		return
 	}

--- a/src/backend/controllers/cluster/cluster.go
+++ b/src/backend/controllers/cluster/cluster.go
@@ -145,13 +145,13 @@ func (c *ClusterController) List() {
 
 	total, err := models.GetTotal(new(models.Cluster), param)
 	if err != nil {
-		logs.Error("get total count by param (%s) error. %v", param, err)
+		logs.Error("get total count by param (%v) error. %v", param, err)
 		c.HandleError(err)
 		return
 	}
 	err = models.GetAll(new(models.Cluster), &clusters, param)
 	if err != nil {
-		logs.Error("list by param (%s) error. %v", param, err)
+		logs.Error("list by param (%v) error. %v", param, err)
 		c.HandleError(err)
 		return
 	}

--- a/src/backend/controllers/configmap/configmap.go
+++ b/src/backend/controllers/configmap/configmap.go
@@ -92,14 +92,14 @@ func (c *ConfigMapController) List() {
 
 	total, err := models.GetTotal(new(models.ConfigMap), param)
 	if err != nil {
-		logs.Error("get total count by param (%s) error. %v", param, err)
+		logs.Error("get total count by param (%v) error. %v", param, err)
 		c.HandleError(err)
 		return
 	}
 
 	err = models.GetAll(new(models.ConfigMap), &configMap, param)
 	if err != nil {
-		logs.Error("list by param (%s) error. %v", param, err)
+		logs.Error("list by param (%v) error. %v", param, err)
 		c.HandleError(err)
 		return
 	}

--- a/src/backend/controllers/cronjob/cronjob.go
+++ b/src/backend/controllers/cronjob/cronjob.go
@@ -92,14 +92,14 @@ func (c *CronjobController) List() {
 
 	total, err := models.GetTotal(new(models.Cronjob), param)
 	if err != nil {
-		logs.Error("get total count by param (%s) error. %v", param, err)
+		logs.Error("get total count by param (%v) error. %v", param, err)
 		c.HandleError(err)
 		return
 	}
 
 	err = models.GetAll(new(models.Cronjob), &cronjob, param)
 	if err != nil {
-		logs.Error("list by param (%s) error. %v", param, err)
+		logs.Error("list by param (%v) error. %v", param, err)
 		c.HandleError(err)
 		return
 	}

--- a/src/backend/controllers/daemonset/daemonset.go
+++ b/src/backend/controllers/daemonset/daemonset.go
@@ -89,14 +89,14 @@ func (c *DaemonSetController) List() {
 
 	total, err := models.GetTotal(new(models.DaemonSet), param)
 	if err != nil {
-		logs.Error("get total count by param (%s) error. %v", param, err)
+		logs.Error("get total count by param (%v) error. %v", param, err)
 		c.HandleError(err)
 		return
 	}
 
 	err = models.GetAll(new(models.DaemonSet), &daemonSets, param)
 	if err != nil {
-		logs.Error("list by param (%s) error. %v", param, err)
+		logs.Error("list by param (%v) error. %v", param, err)
 		c.HandleError(err)
 		return
 	}

--- a/src/backend/controllers/hpa/hpa.go
+++ b/src/backend/controllers/hpa/hpa.go
@@ -81,14 +81,14 @@ func (c *HPAController) List() {
 
 	total, err := models.GetTotal(new(models.HPA), param)
 	if err != nil {
-		logs.Error("get total count by param (%s) error. %v", param, err)
+		logs.Error("get total count by param (%v) error. %v", param, err)
 		c.HandleError(err)
 		return
 	}
 
 	err = models.GetAll(new(models.HPA), &hpas, param)
 	if err != nil {
-		logs.Error("list by param (%s) error. %v", param, err)
+		logs.Error("list by param (%v) error. %v", param, err)
 		c.HandleError(err)
 		return
 	}

--- a/src/backend/controllers/notification/notification.go
+++ b/src/backend/controllers/notification/notification.go
@@ -42,7 +42,7 @@ func (c *NotificationController) List() {
 	notifications := []models.Notification{}
 	total, err := models.GetTotal(new(models.Notification), param)
 	if err != nil {
-		logs.Error("get total count by param (%s) error. %v", param, err)
+		logs.Error("get total count by param (%v) error. %v", param, err)
 		c.HandleError(err)
 		return
 	}
@@ -50,7 +50,7 @@ func (c *NotificationController) List() {
 	param.Relate = "all"
 	err = models.GetAll(new(models.Notification), &notifications, param)
 	if err != nil {
-		logs.Error("list by param (%s) error. %v", param, err)
+		logs.Error("list by param (%v) error. %v", param, err)
 		c.HandleError(err)
 		return
 	}

--- a/src/backend/controllers/permission/app_user.go
+++ b/src/backend/controllers/permission/app_user.go
@@ -72,7 +72,7 @@ func (c *AppUserController) List() {
 
 	total, err := models.GetTotal(new(models.AppUser), param)
 	if err != nil {
-		logs.Error("get total count by param (%s) error. %v", param, err)
+		logs.Error("get total count by param (%v) error. %v", param, err)
 		c.HandleError(err)
 		return
 	}
@@ -80,7 +80,7 @@ func (c *AppUserController) List() {
 
 	err = models.GetAll(new(models.AppUser), &appUsers, param)
 	if err != nil {
-		logs.Error("list by param (%s) error. %v", param, err)
+		logs.Error("list by param (%v) error. %v", param, err)
 		c.HandleError(err)
 		return
 	}

--- a/src/backend/controllers/permission/group.go
+++ b/src/backend/controllers/permission/group.go
@@ -59,7 +59,7 @@ func (c *GroupController) List() {
 
 	total, err := models.GetTotal(new(models.Group), param)
 	if err != nil {
-		logs.Error("get total count by param (%s) error. %v", param, err)
+		logs.Error("get total count by param (%v) error. %v", param, err)
 		c.HandleError(err)
 		return
 	}
@@ -67,7 +67,7 @@ func (c *GroupController) List() {
 	groups := []models.Group{}
 	err = models.GetAll(new(models.Group), &groups, param)
 	if err != nil {
-		logs.Error("list by param (%s) error. %v", param, err)
+		logs.Error("list by param (%v) error. %v", param, err)
 		c.HandleError(err)
 		return
 	}

--- a/src/backend/controllers/permission/namespace_user.go
+++ b/src/backend/controllers/permission/namespace_user.go
@@ -71,7 +71,7 @@ func (c *NamespaceUserController) List() {
 
 	total, err := models.GetTotal(new(models.NamespaceUser), param)
 	if err != nil {
-		logs.Error("get total count by param (%s) error. %v", param, err)
+		logs.Error("get total count by param (%v) error. %v", param, err)
 		c.HandleError(err)
 		return
 	}
@@ -79,7 +79,7 @@ func (c *NamespaceUserController) List() {
 
 	err = models.GetAll(new(models.NamespaceUser), &namespaceUsers, param)
 	if err != nil {
-		logs.Error("list by param (%s) error. %v", param, err)
+		logs.Error("list by param (%v) error. %v", param, err)
 		c.HandleError(err)
 		return
 	}

--- a/src/backend/controllers/permission/permission.go
+++ b/src/backend/controllers/permission/permission.go
@@ -54,7 +54,7 @@ func (c *PermissionController) List() {
 
 	total, err := models.GetTotal(new(models.Permission), param)
 	if err != nil {
-		logs.Error("get total count by param (%s) error. %v", param, err)
+		logs.Error("get total count by param (%v) error. %v", param, err)
 		c.HandleError(err)
 		return
 	}
@@ -62,7 +62,7 @@ func (c *PermissionController) List() {
 	permissions := []models.Permission{}
 	err = models.GetAll(new(models.Permission), &permissions, param)
 	if err != nil {
-		logs.Error("list by param (%s) error. %v", param, err)
+		logs.Error("list by param (%v) error. %v", param, err)
 		c.HandleError(err)
 		return
 	}

--- a/src/backend/controllers/permission/user.go
+++ b/src/backend/controllers/permission/user.go
@@ -78,7 +78,7 @@ func (c *UserController) List() {
 	}
 	total, err := models.GetTotal(new(models.User), param)
 	if err != nil {
-		logs.Error("get total count by param (%s) error. %v", param, err)
+		logs.Error("get total count by param (%v) error. %v", param, err)
 		c.HandleError(err)
 		return
 	}
@@ -86,7 +86,7 @@ func (c *UserController) List() {
 	users := []models.User{}
 	err = models.GetAll(new(models.User), &users, param)
 	if err != nil {
-		logs.Error("list by param (%s) error. %v", param, err)
+		logs.Error("list by param (%v) error. %v", param, err)
 		c.HandleError(err)
 		return
 	}

--- a/src/backend/controllers/pvc/pvc.go
+++ b/src/backend/controllers/pvc/pvc.go
@@ -92,14 +92,14 @@ func (c *PersistentVolumeClaimController) List() {
 
 	total, err := models.GetTotal(new(models.PersistentVolumeClaim), param)
 	if err != nil {
-		logs.Error("get total count by param (%s) error. %v", param, err)
+		logs.Error("get total count by param (%v) error. %v", param, err)
 		c.HandleError(err)
 		return
 	}
 
 	err = models.GetAll(new(models.PersistentVolumeClaim), &pvc, param)
 	if err != nil {
-		logs.Error("list by param (%s) error. %v", param, err)
+		logs.Error("list by param (%v) error. %v", param, err)
 		c.HandleError(err)
 		return
 	}

--- a/src/backend/controllers/secret/secret.go
+++ b/src/backend/controllers/secret/secret.go
@@ -92,14 +92,14 @@ func (c *SecretController) List() {
 
 	total, err := models.GetTotal(new(models.Secret), param)
 	if err != nil {
-		logs.Error("get total count by param (%s) error. %v", param, err)
+		logs.Error("get total count by param (%v) error. %v", param, err)
 		c.HandleError(err)
 		return
 	}
 
 	err = models.GetAll(new(models.Secret), &secret, param)
 	if err != nil {
-		logs.Error("list by param (%s) error. %v", param, err)
+		logs.Error("list by param (%v) error. %v", param, err)
 		c.HandleError(err)
 		return
 	}


### PR DESCRIPTION
Fixes #572 

fix the log format

because the type `QueryParam` don't have the function `String()`
```go
logs.Error("get total count by param (%s) error. %v", param, err)
// should convert to this
logs.Error("get total count by param (%v) error. %v", param, err)
```