### PR TITLE
[issue 573 feature]: add soft delete

### DIFF
--- a/src/backend/controllers/permission/user.go
+++ b/src/backend/controllers/permission/user.go
@@ -233,6 +233,34 @@ func (c *UserController) Update() {
 // @Success 200 {string} delete success!
 // @router /:id [delete]
 func (c *UserController) Delete() {
+	var (
+		id  int64
+		del string
+		err error
+	)
+
+	id = c.GetIDFromURL()
+	// 判断是否需要硬删除
+	del = c.Input().Get("delete")
+	if del == "true" {
+		err = models.UserModel.DeleteUser(int64(id))
+	} else {
+		err = models.UserModel.UpdateUserDeleted(int64(id))
+	}
+	if err != nil {
+		logs.Error("delete %d error.%v", id, err)
+		c.HandleError(err)
+		return
+	}
+	c.Success(nil)
+}
+
+// @Title SoftDelete
+// @Description make the user's deleted true
+// @Param	id		path 	int	true		"The id you want to delete"
+// @Success 200 {string} delete success!
+// @router /:id [delete]
+func (c *UserController) SoftDelete() {
 	id := c.GetIDFromURL()
 
 	err := models.UserModel.DeleteUser(int64(id))

--- a/src/backend/models/user.go
+++ b/src/backend/models/user.go
@@ -265,6 +265,17 @@ func (*userModel) UpdateUserById(m *User) (err error) {
 	return
 }
 
+func (*userModel) UpdateUserDeleted(id int64) (err error) {
+	v := &User{Id: id}
+	if err = Ormer().Read(v); err != nil {
+		return
+	}
+	v.Deleted = true
+	_, err = Ormer().Update(v)
+	return
+}
+
+// 数据库硬删除
 func (*userModel) DeleteUser(id int64) (err error) {
 	v := User{Id: id}
 	if err = Ormer().Read(&v); err != nil {


### PR DESCRIPTION
Fixes #573 

when you delete user in 后台首页 -> 权限 -> 用户列表
![E9BB3BDF9ADBC29E4D3F0EB574112A3B](https://user-images.githubusercontent.com/23120372/86077633-e498e780-babe-11ea-8306-e3c4b27e1860.jpg)

The user will be deleted totally in mysql. I upgrade the logical of delete.
When create a `delete` http request
- `http://localhost:8080/api/v1/users/4`, the user 4 will be deleted softly.
- `http://localhost:8080/api/v1/users/4?delete=true`, the user 4 will be deleted.

If the user 


